### PR TITLE
修改以适配本地化工具

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -8,7 +8,7 @@ module.exports = (file) => {
   const html = fs.readFileSync(filepath).toString()
   const { texts } = html2texts(html)
   const localTexts = texts.reduce((result, { text }) => {
-    return { ...result, [text]: '' }
+    return { ...result, [text]: text }
   }, {})
 
   fs.writeFile(outpath, JSON.stringify(localTexts, null, 2), (err) => {


### PR DESCRIPTION
实际上本地化工具里像这样：
`"Hello" : "Hello"`
并不是文字对应文字的关系，而是：
左边为说明本字符串的参考信息，右边才是源字符串(原文)。
所以最好导出时生成两次。
附：Crowdin里Json文件例子：
```json
//原文
{
    "author": {
        "addNewAuthor": "Add new author",
        "author": "Author",
        "authorDataParsingErrorMessage": "An error occurred during parsing of author data for ID: ",
        "authorHasBeenUpdated": "Author has been updated",
        "authorLink": "Author link",
        "authorName": "Author name"
  }
}
//译文
{
    "author": {
        "addNewAuthor": "新增作者",
        "author": "作者",
        "authorDataParsingErrorMessage": "解析 ID 的作者数据时出错： ",
        "authorHasBeenUpdated": "作者已更新",
        "authorLink": "作者链接",
        "authorName": "作者姓名"
  }
}
```